### PR TITLE
Please recompile with a newer version of stdlib + golang.org/x/crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Teradata SQL Driver for Python
+## Teradata SQL Driver for Python!
 
 This package enables Python applications to connect to the Teradata Database.
 


### PR DESCRIPTION
Hey folks; the latest version of `teradatasql` 20.0.0.20 (specifically the artifacts `teradatasql.dylib` and `teradatasql.so`) was compiled against `stdlib` version 1.22.4. This version of `stdlib` is affected by the following vulnerabilities:

- CVE-2024-34158
- CVE-2024-24791
- CVE-2024-34156
- CVE-2024-34155

That library also includes the Go dependency `golang.org/x/crypto` version 0.24.0, which is subject to the following vulnerability:

- CVE-2024-45337

Many vulnerability scanners score these as "high severity," which means that enterprise users will have difficulty availing themselves of this library in secure environments.

Would it be possible to release a fresh build against:

- `stdlib` version 1.22.7 or newer
- `golang.org/x/crypto` version 0.31.0 or newer

Thanks in advance!